### PR TITLE
improve error handling

### DIFF
--- a/controllers/base/commonSteps.js
+++ b/controllers/base/commonSteps.js
@@ -23,18 +23,15 @@ function getCompendiumID(passon) {
                 return;
             }
             // status responses
-            if(response.statusCode === 404) {
+            if(response.status >= 400 || response.statusCode >= 400) {
                 let error = new Error();
-                error.msg = 'no compendium found';
+                if (response.status >= 500 || response.statusCode >= 500) {
+                    error.msg = 'o2r service not accessible'
+                } else {
+                    error.msg = 'no compendium found';
+                }
                 error.status = 404;
                 error.badgeNA = true;
-                reject(error);
-                return;
-            }
-            else if(response.statusCode === 500 || response.status === 500) {
-                let error = new Error();
-                error.msg = 'error filtering for doi';
-                error.status = 404;
                 reject(error);
                 return;
             }
@@ -78,19 +75,16 @@ function getCompendium(passon) {
                 reject(error);
                 return;
             }
-            // status responses
-            if(response.status === 404) {
+
+            if(response.status >= 400 || response.statusCode >= 400) {
                 let error = new Error();
-                error.msg = 'no compendium found';
+                if (response.status >= 500 || response.statusCode >= 500) {
+                    error.msg = 'o2r service not accessible'
+                } else {
+                    error.msg = 'no compendium found';
+                }
                 error.status = 404;
                 error.badgeNA = true;
-                reject(error);
-                return;
-            }
-            else if(response.status === 500) {
-                let error = new Error();
-                error.msg = 'Unable to access server';
-                error.status = 500;
                 reject(error);
                 return;
             }
@@ -120,19 +114,16 @@ function getJobID(passon) {
                 reject(error);
                 return;
             }
-            // status responses
-            if(response.status === 404) {
+
+            if(response.status >= 400 || response.statusCode >= 400) {
                 let error = new Error();
-                error.msg = 'no job found';
+                if (response.status >= 500 || response.statusCode >= 500) {
+                    error.msg = 'o2r service not accessible'
+                } else {
+                    error.msg = 'no job found';
+                }
                 error.status = 404;
                 error.badgeNA = true;
-                reject(error);
-                return;
-            }
-            else if(response.status === 500) {
-                let error = new Error();
-                error.msg = 'Unable to find data on server';
-                error.status = 404;
                 reject(error);
                 return;
             }
@@ -163,19 +154,16 @@ function getJob(passon) {
                 reject(error);
                 return;
             }
-            // status responses
-            if(response.status === 404) {
+
+            if(response.status >= 400 || response.statusCode >= 400) {
                 let error = new Error();
-                error.msg = 'no job data found';
+                if (response.status >= 500 || response.statusCode >= 500) {
+                    error.msg = 'o2r service not accessible'
+                } else {
+                    error.msg = 'no job data found';
+                }
                 error.status = 404;
                 error.badgeNA = true;
-                reject(error);
-                return;
-            }
-            else if(response.status === 500) {
-                let error = new Error();
-                error.msg = 'Unable to find data on server';
-                error.status = 404;
                 reject(error);
                 return;
             }

--- a/controllers/license/license.js
+++ b/controllers/license/license.js
@@ -214,7 +214,7 @@ function getLicenseFromDOAJ(passon) {
                 } catch (err) {
                     err.msg = 'error getting license from doaj';
                     err.badgeNA = true;
-                    reject(error);
+                    reject(err);
                     return;
                 }
                 fulfill(passon); 

--- a/controllers/release-date/release-date.js
+++ b/controllers/release-date/release-date.js
@@ -142,10 +142,11 @@ function getReleaseTime(passon) {
                     error.status = 404;
                     reject(error);
                     return;
-                } else if (response.status === 500 || response.statusCode === 500) {
+                } else if (response.status >= 400 || response.statusCode >= 400) {
                     let error = new Error();
                     error.msg = 'Unable to find data on server';
                     error.status = 500;
+                    error.badgeNA = true;
                     reject(error);
                     return;
                 }

--- a/controllers/review-status/review-status.js
+++ b/controllers/review-status/review-status.js
@@ -236,10 +236,10 @@ function sendResponse(passon) {
         try {
             process = data.results[0].bibjson.editorial_review.process;
             debug('Review process for DOI %s is "%s"', passon.id, process);
-        } catch (error) {
-            error.msg = 'error accessing doaj';
-            error.badgeNA = true;
-            reject(error);
+        } catch (err) {
+            err.msg = 'error accessing doaj';
+            err.badgeNA = true;
+            reject(err);
             return;
         }
 

--- a/controllers/review-status/review-status.js
+++ b/controllers/review-status/review-status.js
@@ -117,13 +117,26 @@ function getISSN(passon) {
                 return;
             }
 
+            if(response.status >= 400 || response.statusCode >= 400) {
+                let error = new Error();
+                if (response.status >= 500 || response.statusCode >= 500) {
+                    error.msg = 'error accessing doaj'
+                } else {
+                    error.msg = 'no doaj data found';
+                }
+                error.status = 404;
+                error.badgeNA = true;
+                reject(error);
+                return;
+            }
+
             let data;
             try {
                 data = JSON.parse(body);
             } catch (err) {
-                err.msg = 'error accessing doaj';
+                err.msg = 'error parsing doaj response';
                 err.badgeNA = true;
-                reject(error);
+                reject(err);
                 return;
             }
 
@@ -186,6 +199,20 @@ function getReviewStatus(passon) {
                 reject(error);
                 return;
             }
+
+            if(response.status >= 400 || response.statusCode >= 400) {
+                let error = new Error();
+                if (response.status >= 500 || response.statusCode >= 500) {
+                    error.msg = 'error accessing doaj'
+                } else {
+                    error.msg = 'no doaj data found';
+                }
+                error.status = 404;
+                error.badgeNA = true;
+                reject(error);
+                return;
+            }
+
             passon.body = JSON.parse(body);
             fulfill(passon);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o2r-badger",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Generate scalable badges for research",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When requesting data from external services, such as DOAJ or Crossref, sometimes errors were not handled correctly. For example, the response was checked for "statusCode" but only contained a property "status".

Now all responses are checked for status/statusCodes >= 400