### PR TITLE
add piwik API tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,11 @@ Additional Piwik API tracking settings:
 - `c.tracking.piwikSiteID`
   Piwik site ID. Can be found in the [piwik tracking code](https://developer.piwik.org/guides/tracking-javascript-guide#finding-the-piwik-tracking-code).
 
-c.tracking.piwikURL = 'https://o2r.uni-muenster.de/piwik/piwik.php';
-c.tracking.piwikBaseURL = 'https://o2r.uni-muenster.de';
-c.tracking.piwikSiteID = 4;
+## Piwik
+
+The badger tracks API requests using [Piwik](https://piwik.org/) except for requests with a "do not track" header.
+
+A (local) piwik server can be set up [manually](https://piwik.org/docs/installation/) or [using Docker Compose](http://www.bauerspace.com/set-up-piwik-in-docker/).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ They are picked up in the file `config/config.js` where all configuration settin
   The address used to query the o2r [API](http://o2r.info/o2r-web-api/) . Defaults to `https://o2r.uni-muenster.de`.
 - `BADGER_TEST_ENDPOINT`
   The address used for tests. Defaults to `http://localhost`
+- `DISABLE_TRACKING`
+  Disables [Piwik](https://piwik.org/) API tracking when set to `true`. Defaults to `false`.
+- `PIWIK_TOKEN`
+  The secret piwik token used to access the Piwik tracking server.
 
 Other settings in `config.js` without corresponding environment variable:
 
@@ -165,6 +169,19 @@ Other settings in `config.js` without corresponding environment variable:
   o2r endpoint. Can be modified via `BADGER_O2R_HOST`.
 - `c.ext.doajArticles` and `c.ext.doajJournals`
   DOAJ search endpoint for articles and journals.
+
+Additional Piwik API tracking settings:
+
+- `c.tracking.piwikURL`
+  Piwik server address.
+- `c.tracking.piwikBaseURL`
+  Piwik base URL which is prepended to all API routes.
+- `c.tracking.piwikSiteID`
+  Piwik site ID. Can be found in the [piwik tracking code](https://developer.piwik.org/guides/tracking-javascript-guide#finding-the-piwik-tracking-code).
+
+c.tracking.piwikURL = 'https://o2r.uni-muenster.de/piwik/piwik.php';
+c.tracking.piwikBaseURL = 'https://o2r.uni-muenster.de';
+c.tracking.piwikSiteID = 4;
 
 ## Development
 

--- a/config/config.js
+++ b/config/config.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
  */
+
+const yn = require('yn');
+
 var c = {};
 c.net = {};
 c.ext = {};
@@ -37,7 +40,7 @@ c.net.testEndpoint = env.BADGER_ENDPOINT || 'http://localhost';
 c.net.proxy = '';
 
 //piwik tracking options
-c.tracking.disableTracking = env.DISABLE_TRACKING || 'false';
+c.tracking.disableTracking = yn(env.DISABLE_TRACKING) || false;
 c.tracking.piwikToken = env.PIWIK_TOKEN;
 c.tracking.piwikURL = 'https://o2r.uni-muenster.de/piwik/piwik.php';
 c.tracking.piwikBaseURL = 'https://o2r.uni-muenster.de';

--- a/config/config.js
+++ b/config/config.js
@@ -18,6 +18,7 @@ var c = {};
 c.net = {};
 c.ext = {};
 c.timeout = {};
+c.badge = {};
 c.executable = {};
 c.peerreview = {};
 c.licence = {};
@@ -55,31 +56,35 @@ c.timeout.o2r  = 2500;
 c.timeout.doaj  = 2500;
 c.timeout.geonames  = 2500;
 
+//badge settings
+c.badge.baseURL = 'https://img.shields.io/badge/';
+c.badge.options = '?style=flat-square';
+
 //badges
 c.executable.services = ['o2r'];
 c.executable.mainService = 'o2r';
-c.executable.badgeNASmall = 'https://img.shields.io/badge/executable-n%2Fa-9f9f9f.svg';
+c.executable.badgeNASmall = 'https://img.shields.io/badge/executable-n%2Fa-9f9f9f.svg' + c.badge.options;
 c.executable.badgeNABig = 'badges/Executable_noInfo.svg';
 
 c.licence.services = ['o2r'];
 c.licence.mainService = 'o2r';
-c.licence.badgeNASmall = 'https://img.shields.io/badge/licence-n%2Fa-9f9f9f.svg';
+c.licence.badgeNASmall = 'https://img.shields.io/badge/licence-n%2Fa-9f9f9f.svg' + c.badge.options;
 c.licence.badgeNABig = 'badges/license_noInformation.svg';
 
 c.spatial.services = ['o2r'];
 c.spatial.mainService = 'o2r';
-c.spatial.badgeNASmall = 'https://img.shields.io/badge/location-n%2Fa-lightgrey.svg';
+c.spatial.badgeNASmall = 'https://img.shields.io/badge/location-n%2Fa-lightgrey.svg' + c.badge.options;
 c.spatial.badgeNABig = 'indexNoMap.html';
 c.spatial.bboxPath = 'metadata.o2r.spatial.spatial.union.geojson.bbox';
 
 c.releasetime.services = ['crossref'];
 c.releasetime.mainService = 'crossref';
-c.releasetime.badgeNASmall = 'https://img.shields.io/badge/release%20time-n%2Fa-lightgrey.svg';
+c.releasetime.badgeNASmall = 'https://img.shields.io/badge/release%20time-n%2Fa-lightgrey.svg' + c.badge.options;
 c.releasetime.badgeNABig = 'badges/released_no_information.svg';
 
 c.peerreview.services = ['doaj'];
 c.peerreview.mainService = 'doaj';
-c.peerreview.badgeNASmall = 'https://img.shields.io/badge/peer%20review-n%2Fa-lightgrey.svg';
+c.peerreview.badgeNASmall = 'https://img.shields.io/badge/peer%20review-n%2Fa-lightgrey.svg' + c.badge.options;
 c.peerreview.badgeNABig = '';
 
 module.exports = c;

--- a/config/config.js
+++ b/config/config.js
@@ -23,6 +23,7 @@ c.peerreview = {};
 c.licence = {};
 c.spatial = {};
 c.releasetime = {};
+c.tracking = {};
 var env = process.env;
 
 // Information about badger
@@ -33,6 +34,13 @@ c.version = require('../package.json').version;
 c.net.port = env.BADGER_PORT || 8089;
 c.net.testEndpoint = env.BADGER_ENDPOINT || 'http://localhost';
 c.net.proxy = '';
+
+//piwik tracking options
+c.tracking.disableTracking = env.DISABLE_TRACKING || 'false';
+c.tracking.piwikToken = env.PIWIK_TOKEN;
+c.tracking.piwikURL = 'https://o2r.uni-muenster.de/piwik/piwik.php';
+c.tracking.piwikBaseURL = 'https://o2r.uni-muenster.de';
+c.tracking.piwikSiteID = 4;
 
 //external resources/APIs
 c.ext.crossref = 'https://api.crossref.org/works/';

--- a/controllers/base/base.js
+++ b/controllers/base/base.js
@@ -68,12 +68,10 @@ exports.resizeAndSend = (req, res) => {
 					res.status(500).send('Converting of svg to png not possible!');
 				} else {
 					let img = new Buffer(result, "base64");
-					let service = (req.service !== undefined) ? req.service :'unknown';
 					res.writeHead(200, {
 						'Access-Control-Allow-Origin': '*',
 						'Content-Type': 'image/png',
-						'Content-Length': img.length,
-						'x-badger-service': service
+						'Content-Length': img.length
 					});
 					res.end(img);
 				}

--- a/controllers/base/base.js
+++ b/controllers/base/base.js
@@ -68,10 +68,12 @@ exports.resizeAndSend = (req, res) => {
 					res.status(500).send('Converting of svg to png not possible!');
 				} else {
 					let img = new Buffer(result, "base64");
+					let service = (req.service !== undefined) ? req.service :'unknown';
 					res.writeHead(200, {
 						'Access-Control-Allow-Origin': '*',
 						'Content-Type': 'image/png',
-						'Content-Length': img.length
+						'Content-Length': img.length,
+						'x-badger-service': service
 					});
 					res.end(img);
 				}
@@ -79,7 +81,7 @@ exports.resizeAndSend = (req, res) => {
 		});
 	} else {
 		if (typeof req.options !== 'undefined') {
-			res.sendFile(req.filePath);
+			res.sendFile(req.filePath, req.options);
 		} else {
 			res.sendFile(req.filePath, req.options, function(err) {
 				if(err) {

--- a/controllers/base/commonSteps.js
+++ b/controllers/base/commonSteps.js
@@ -8,6 +8,7 @@ function getCompendiumID(passon) {
     return new Promise((fulfill, reject) => {
         let requestURL = config.ext.o2r + '/api/v1/compendium?doi=' + passon.id;
         debug('Fetching compendium ID from %s with URL', config.ext.o2r, requestURL);
+        passon.service = 'o2r';
 
         request({
             url: requestURL,
@@ -61,6 +62,7 @@ function getCompendium(passon) {
     return new Promise((fulfill, reject) => {
         let requestURL = config.ext.o2r + '/api/v1/compendium/' + passon.compendiumID;
         debug('Fetching license status for compendium %s from %s', passon.compendiumID, requestURL);
+        passon.service = 'o2r';
 
         request({
             url: requestURL,
@@ -100,6 +102,7 @@ function getJobID(passon) {
     return new Promise((fulfill, reject) => {
         let requestURL = config.ext.o2r + '/api/v1/job?compendium_id=' + passon.compendiumID;
         debug('Fetching job ID for compendium %s from %s', passon.compendiumID, requestURL);
+        passon.service = 'o2r';
 
         request({
             url: requestURL,
@@ -140,6 +143,7 @@ function getJob(passon) {
     return new Promise((fulfill, reject) => {
         let requestURL = config.ext.o2r + '/api/v1/job/' + passon.jobID;
         debug('Fetching job status for job %s from %s', passon.jobID, requestURL);
+        passon.service = 'o2r';
 
         request({
             url: requestURL,

--- a/controllers/executability/executability.js
+++ b/controllers/executability/executability.js
@@ -22,10 +22,10 @@ exports.getBadgeFromData = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "executable"
     if (base.hasSupportedService(config.executable) === false) {
@@ -90,10 +90,10 @@ exports.getBadgeFromReference = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "executable"
     if (base.hasSupportedService(config.executable) === false) {

--- a/controllers/executability/executability.js
+++ b/controllers/executability/executability.js
@@ -152,7 +152,7 @@ function sendResponse(passon) {
             return;
         }
 
-        let redirectURL;
+        let badgeString;
         // request options
         let options = {
             dotfiles: 'deny',
@@ -193,21 +193,21 @@ function sendResponse(passon) {
             //if the status is 'success' the green badge is sent to the client
             if (passon.jobStatus === 'success') {
                 // send the reponse from our server
-                redirectURL = 'https://img.shields.io/badge/executable-yes-44cc11.svg';
+                badgeString = config.badge.baseURL + 'executable-yes-44cc11.svg' + config.badge.options;
             }
             // for a 'fail' the red badge is sent
             else if (passon.jobStatus === 'failure') {
-                redirectURL = 'https://img.shields.io/badge/executable-no-ff0000.svg';
+                badgeString = config.badge.baseURL + 'executable-no-ff0000.svg' + config.badge.options;
             }
             // and for the running status the yellow badge is sent to the client
             else if (passon.jobStatus === 'running') {
-                redirectURL = 'https://img.shields.io/badge/executable-running-yellow.svg';
+                badgeString = config.badge.baseURL + 'executable-running-yellow.svg' + config.badge.options;
             }
             else {
-                redirectURL = 'https://img.shields.io/badge/executable-n%2Fa-9f9f9f.svg';
+                badgeString = config.badge.baseURL + 'executable-n%2Fa-9f9f9f.svg' + config.badge.options;
             }
             passon.res.tracking.service = passon.service;
-            passon.res.redirect(redirectURL);
+            passon.res.redirect(badgeString);
             fulfill(passon);
         } else {
             let error = new Error();

--- a/controllers/license/license.js
+++ b/controllers/license/license.js
@@ -31,10 +31,10 @@ exports.getBadgeFromData = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "licence"
     if (base.hasSupportedService(config.licence) === false) {
@@ -100,10 +100,10 @@ exports.getBadgeFromReference = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "licence"
     if (base.hasSupportedService(config.licence) === false) {
@@ -400,6 +400,7 @@ function sendResponse(passon) {
             passon.req.options = options;
             debug('Sending SVG %s to scaling service', passon.req.filePath);
             base.resizeAndSend(passon.req, passon.res);
+            fulfill(passon);
         }
         else {
             if(osicode===true && oddata===true && odtext===true){
@@ -479,7 +480,7 @@ function sendResponse(passon) {
             passon.res.tracking.service = passon.service;
             let redirectURL = config.badge.baseURL + badgeString + config.badge.options;
             passon.res.redirect(redirectURL);
+            fulfill(passon);
         }
-        fulfill(passon);
     });
 }

--- a/controllers/license/license.js
+++ b/controllers/license/license.js
@@ -280,7 +280,7 @@ function sendResponse(passon) {
         }
 
         let localPath;
-        let redirectURL;
+        let badgeString;
         let osicode = passon.osiCode;
         let oddata = passon.odData;
         let odtext = passon.odText;
@@ -403,81 +403,82 @@ function sendResponse(passon) {
         }
         else {
             if(osicode===true && oddata===true && odtext===true){
-                redirectURL = 'https://img.shields.io/badge/licence-open-44cc11.svg';
+                badgeString = 'licence-open-44cc11.svg';
             }
             else if(osicode===false && oddata===true && odtext===true || osicode===true && oddata===false && odtext===true || osicode===true && oddata===true && odtext===false){
-                redirectURL = 'https://img.shields.io/badge/licence-mostly%20open-yellow.svg';
+                badgeString = 'licence-mostly%20open-yellow.svg';
             }
             else if(osicode===false && oddata===false && odtext===true || osicode===false && oddata===true && odtext===false || osicode===true && oddata===false && odtext===false){
-                redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                badgeString = 'licence-partially%20open-fe7d00.svg';
             }
             else if(osicode===false && oddata===false && odtext===false){
-                redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                badgeString = 'licence-closed-ff0000.svg';
             }
             //cases for unknown licences for one tag
             else if(osicode === 'unknown') {
                 if(oddata === true && odtext === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-mostly%20open-yellow.svg';
+                    badgeString = 'licence-mostly%20open-yellow.svg';
                 }
                 else if(oddata === true && odtext === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(oddata === false && odtext === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(oddata === false && odtext === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                    badgeString = 'licence-closed-ff0000.svg';
                 }
                 else if(oddata === 'unknown' && odtext === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                    badgeString = 'licence-closed-ff0000.svg';
                 }
                 else if(oddata === 'unknown' && odtext === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(oddata === false && odtext === 'unknown') {
-                    redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                    badgeString = 'licence-closed-ff0000.svg';
                 }
                 else if(oddata === true && odtext === 'unknown') {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
             }
             else if(oddata === 'unknown') {
                 if(osicode === true && odtext === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-mostly%20open-yellow.svg';
+                    badgeString = 'licence-mostly%20open-yellow.svg';
                 }
                 else if(osicode === true && odtext === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(osicode === false && odtext === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(osicode === false && odtext === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                    badgeString = 'licence-closed-ff0000.svg';
                 }
                 else if(osicode === false && odtext === 'unknown') {
-                    redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                    badgeString = 'licence-closed-ff0000.svg';
                 }
                 else if(osicode === true && odtext === 'unknown') {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
             }
             else if(odtext === 'unknown') {
                 if(osicode === true && oddata === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-mostly%20open-yellow.svg';
+                    badgeString = 'licence-mostly%20open-yellow.svg';
                 }
                 else if(osicode === true && oddata === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(osicode === false && oddata === true) {
-                    redirectURL = 'https://img.shields.io/badge/licence-partially%20open-fe7d00.svg';
+                    badgeString = 'licence-partially%20open-fe7d00.svg';
                 }
                 else if(osicode === false && oddata === false) {
-                    redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
+                    badgeString = 'licence-closed-ff0000.svg';
                 }
             }
 
             passon.res.tracking.service = passon.service;
-            passon.res.redirect(redirectURL);
+            let redirectURL = config.badge.baseURL + badgeString + config.badge.options;
+            passon.res.redirect(badgeString);
         }
         fulfill(passon);
     });

--- a/controllers/license/license.js
+++ b/controllers/license/license.js
@@ -27,6 +27,15 @@ exports.getBadgeFromData = (req, res) => {
         res: res
     };
 
+    // save tracking info
+    passon.res.tracking = {
+        type: req.params.type,
+        doi: passon.id,
+        extended: (passon.extended === 'extended') ? true : false,
+        size: req.query.width,
+        format: (req.query.format === undefined) ? 'svg' : req.query.format
+    }
+
     // check if there is a service for "licence"
     if (base.hasSupportedService(config.licence) === false) {
         debug('No service for badge %s found', passon.id);
@@ -43,14 +52,14 @@ exports.getBadgeFromData = (req, res) => {
             if (err.badgeNA === true) { // Send 'N/A' badge
                 debug("No badge information found: %s", err.msg);
                 if (passon.extended === 'extended') {
+                    passon.res.na = true;
+                    passon.res.service = passon.service;
                     passon.req.filePath = path.join(__dirname, badgeNABig);
                     base.resizeAndSend(passon.req, passon.res);
                 } else if (passon.extended === undefined) {
-                    if (passon.service) {
-                        res.redirect(badgeNASmall + '?service=' + passon.service)
-                    } else {
-                        res.redirect(badgeNASmall);
-                    }
+                    res.na = true;
+                    res.tracking.service = passon.service;
+                    res.redirect(badgeNASmall);
                 } else {
                     res.status(404).send('not allowed');
                 }
@@ -87,6 +96,15 @@ exports.getBadgeFromReference = (req, res) => {
         res: res
     };
 
+    // save tracking info
+    passon.res.tracking = {
+        type: req.params.type,
+        doi: passon.id,
+        extended: (passon.extended === 'extended') ? true : false,
+        size: req.query.width,
+        format: (req.query.format === undefined) ? 'svg' : req.query.format
+    }
+
     // check if there is a service for "licence"
     if (base.hasSupportedService(config.licence) === false) {
         debug('No service for badge %s found', passon.id);
@@ -106,14 +124,14 @@ exports.getBadgeFromReference = (req, res) => {
             if (err.badgeNA === true) { // Send "N/A" badge
                 debug("No badge information found: %s", err.msg);
                 if (passon.extended === 'extended') {
+                    passon.res.na = true;
+                    passon.res.service = passon.service;
                     passon.req.filePath = path.join(__dirname, badgeNABig);
                     base.resizeAndSend(passon.req, passon.res);
                 } else if (passon.extended === undefined) {
-                    if (passon.service) {
-                        res.redirect(badgeNASmall + '?service=' + passon.service)
-                    } else {
-                        res.redirect(badgeNASmall);
-                    }
+                    res.na = true;
+                    res.tracking.service = passon.service;
+                    res.redirect(badgeNASmall);
                 } else {
                     res.status(404).send('not allowed');
                 }
@@ -369,18 +387,16 @@ function sendResponse(passon) {
 
             // request options
             let options = {
-                //root: __dirname + '/badges/',
                 dotfiles: 'deny',
                 headers: {
                     'x-timestamp': Date.now(),
                     'x-sent': true,
-                    'x-badger-service': passon.service
                 }
             };
 
             // Send the request (+ scaling)
             passon.req.filePath = path.join(__dirname, localPath);
-            passon.req.service = passon.service;
+            passon.res.tracking.service = passon.service;
             passon.req.options = options;
             debug('Sending SVG %s to scaling service', passon.req.filePath);
             base.resizeAndSend(passon.req, passon.res);
@@ -459,7 +475,9 @@ function sendResponse(passon) {
                     redirectURL = 'https://img.shields.io/badge/licence-closed-ff0000.svg';
                 }
             }
-            passon.res.redirect(redirectURL + '?service=' + passon.service);
+
+            passon.res.tracking.service = passon.service;
+            passon.res.redirect(redirectURL);
         }
         fulfill(passon);
     });

--- a/controllers/license/license.js
+++ b/controllers/license/license.js
@@ -478,7 +478,7 @@ function sendResponse(passon) {
 
             passon.res.tracking.service = passon.service;
             let redirectURL = config.badge.baseURL + badgeString + config.badge.options;
-            passon.res.redirect(badgeString);
+            passon.res.redirect(redirectURL);
         }
         fulfill(passon);
     });

--- a/controllers/location/location.js
+++ b/controllers/location/location.js
@@ -277,12 +277,13 @@ function sendSmallBadge(passon) {
         if (passon.service === undefined) {
             passon.service = 'unknown';
         }
-        let redirectURL;
+        let badgeString;
         
         // Encode badge string
         let locationString = passon.geoName.replace('-', '%20');
-        redirectURL = "https://img.shields.io/badge/location-" + locationString + "-blue.svg";
+        badgeString = 'location-' + locationString + '-blue.svg';
         passon.res.tracking.service = passon.service;
+        let redirectURL = config.badge.baseURL + badgeString + config.badge.options;
         passon.res.redirect(redirectURL);
         fulfill(passon);
     });

--- a/controllers/location/location.js
+++ b/controllers/location/location.js
@@ -26,10 +26,10 @@ exports.getBadgeFromData = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "spatial" badges
     if (base.hasSupportedService(config.spatial) === false) {
@@ -104,10 +104,10 @@ exports.getBadgeFromReference = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "spatial" badges
     if (base.hasSupportedService(config.spatial) === false) {

--- a/controllers/release-date/release-date.js
+++ b/controllers/release-date/release-date.js
@@ -22,10 +22,10 @@ exports.getBadgeFromData = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "releasetime" badges
     if (base.hasSupportedService(config.releasetime) === false) {
@@ -91,10 +91,10 @@ exports.getBadgeFromReference = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "releasetime" badges
     if (base.hasSupportedService(config.releasetime) === false) {

--- a/controllers/release-date/release-date.js
+++ b/controllers/release-date/release-date.js
@@ -256,7 +256,7 @@ function sendResponse(passon) {
         if (passon.service === undefined) {
             passon.service = 'unknown';
         }
-        let redirectURL;
+        let badgeString;
         let options = {
             dotfiles: 'deny',
             headers: {
@@ -305,9 +305,9 @@ function sendResponse(passon) {
         /************* send small badges ********************/
         else {
             // send a badge showing the created date
-            redirectURL = 'https://img.shields.io/badge/release%20time-' + passon.releaseYear + '-blue.svg';
+            badgeString = config.badge.baseURL + 'release%20time-' + passon.releaseYear + '-blue.svg' + config.badge.options;
             passon.res.tracking.service = passon.service;
-            passon.res.redirect(redirectURL);
+            passon.res.redirect(badgeString);
             fulfill(passon);
         }
     });

--- a/controllers/review-status/review-status.js
+++ b/controllers/review-status/review-status.js
@@ -259,7 +259,7 @@ function sendResponse(passon) {
         if (passon.service === undefined) {
             passon.service = 'unknown';
         }
-        let redirectURL;
+        let badgeString;
 
         try {
             process = data.results[0].bibjson.editorial_review.process;
@@ -287,16 +287,16 @@ function sendResponse(passon) {
                 passon.reviewStatus = 'yes';
             }
             debug('Sending badge for review status %s', passon.reviewStatus);
-            redirectURL = generateBadge(passon.reviewStatus);
+            badgeString = generateBadge(passon.reviewStatus);
             passon.res.tracking.service = passon.service;
-            passon.res.redirect(redirectURL);
+            passon.res.redirect(badgeString);
             fulfill(passon);
         }
     });
 }
 
 function generateBadge(text) {
-    let shieldsIO = 'https://img.shields.io/badge/peer%20review-';
+    let shieldsIO = config.badge.baseURL + 'peer%20review-';
     let color = '-green.svg';
-    return shieldsIO + encodeURIComponent(text) + color;
+    return shieldsIO + encodeURIComponent(text) + color + config.badge.options;
 }

--- a/controllers/review-status/review-status.js
+++ b/controllers/review-status/review-status.js
@@ -20,10 +20,10 @@ exports.getBadgeFromData = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "peerreview" badges
     if (base.hasSupportedService(config.peerreview) === false) {
@@ -79,10 +79,10 @@ exports.getBadgeFromReference = (req, res) => {
     passon.res.tracking = {
         type: req.params.type,
         doi: passon.id,
-        extended: (passon.extended === 'extended') ? true : false,
+        extended: (passon.extended === 'extended'),
         size: req.query.width,
         format: (req.query.format === undefined) ? 'svg' : req.query.format
-    }
+    };
 
     // check if there is a service for "peerreview" badges
     if (base.hasSupportedService(config.peerreview) === false) {

--- a/controllers/review-status/review-status.js
+++ b/controllers/review-status/review-status.js
@@ -16,6 +16,15 @@ exports.getBadgeFromData = (req, res) => {
         res: res
     };
 
+    // save tracking info
+    passon.res.tracking = {
+        type: req.params.type,
+        doi: passon.id,
+        extended: (passon.extended === 'extended') ? true : false,
+        size: req.query.width,
+        format: (req.query.format === undefined) ? 'svg' : req.query.format
+    }
+
     // check if there is a service for "peerreview" badges
     if (base.hasSupportedService(config.peerreview) === false) {
         debug('No service for badge %s found', passon.id);
@@ -30,11 +39,9 @@ exports.getBadgeFromData = (req, res) => {
         .catch(err => {
             if (err.badgeNA === true) { // Send "N/A" badge
                 debug("No badge information found: %s", err.msg);
-                if (passon.service) {
-                    res.redirect(badgeNASmall + '?service=' + passon.service)
-                } else {
-                    res.redirect(badgeNASmall);
-                }
+                res.na = true;
+                res.tracking.service = passon.service;
+                res.redirect(badgeNASmall);
             } else { // Send error response
                 debug('Error generating badge: "%s" Original request: "%s"', err, passon.req.url);
                 let status = 500;
@@ -68,6 +75,15 @@ exports.getBadgeFromReference = (req, res) => {
         res: res
     };
 
+    // save tracking info
+    passon.res.tracking = {
+        type: req.params.type,
+        doi: passon.id,
+        extended: (passon.extended === 'extended') ? true : false,
+        size: req.query.width,
+        format: (req.query.format === undefined) ? 'svg' : req.query.format
+    }
+
     // check if there is a service for "peerreview" badges
     if (base.hasSupportedService(config.peerreview) === false) {
         debug('No service for badge %s found', passon.id);
@@ -85,11 +101,9 @@ exports.getBadgeFromReference = (req, res) => {
         .catch(err => {
             if (err.badgeNA === true) { // Send "N/A" badge
                 debug("No badge information found: %s", err.msg);
-                if (passon.service) {
-                    res.redirect(badgeNASmall + '?service=' + passon.service)
-                } else {
-                    res.redirect(badgeNASmall);
-                }
+                res.na = true;
+                res.tracking.service = passon.service;
+                res.redirect(badgeNASmall);
             } else { // Send error response
                 debug('Error generating badge: "%s" Original request: "%s"', err, passon.req.url);
                 let status = 500;
@@ -274,7 +288,8 @@ function sendResponse(passon) {
             }
             debug('Sending badge for review status %s', passon.reviewStatus);
             redirectURL = generateBadge(passon.reviewStatus);
-            passon.res.redirect(redirectURL + '?service=' + passon.service);
+            passon.res.tracking.service = passon.service;
+            passon.res.redirect(redirectURL);
             fulfill(passon);
         }
     });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const bodyParser = require('body-parser');
 const piwikTracker = require('./lib/express-piwik-tracker.js');
 
 // track all API requests with piwik middleware
-if (config.tracking.disableTracking !== 'true') {
+if(!config.tracking.disableTracking) {
     app.use(piwikTracker({
         siteId    : config.tracking.piwikSiteID,
         piwikUrl  : config.tracking.piwikURL,

--- a/index.js
+++ b/index.js
@@ -8,13 +8,15 @@ const app = express();
 const bodyParser = require('body-parser');
 const piwikTracker = require('./lib/express-piwik-tracker.js');
 
-//track API requests with piwik
-app.use(piwikTracker({
-    siteId    : config.tracking.piwikSiteID,
-    piwikUrl  : config.tracking.piwikURL,
-    baseUrl   : config.tracking.piwikBaseURL,
-    piwikToken: config.tracking.piwikToken
-}));
+// track all API requests with piwik middleware
+if (config.tracking.disableTracking !== 'true') {
+    app.use(piwikTracker({
+        siteId    : config.tracking.piwikSiteID,
+        piwikUrl  : config.tracking.piwikURL,
+        baseUrl   : config.tracking.piwikBaseURL,
+        piwikToken: config.tracking.piwikToken
+    }));
+}
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies

--- a/index.js
+++ b/index.js
@@ -6,6 +6,15 @@ const request = require('request');
 const express = require('express');
 const app = express();
 const bodyParser = require('body-parser');
+const piwikTracker = require('./lib/express-piwik-tracker.js');
+
+//track API requests with piwik
+app.use(piwikTracker({
+    siteId    : config.tracking.piwikSiteID,
+    piwikUrl  : config.tracking.piwikURL,
+    baseUrl   : config.tracking.piwikBaseURL,
+    piwikToken: config.tracking.piwikToken
+}));
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -1,0 +1,32 @@
+// piwik tracking middleware, from https://piwik.org/blog/2014/06/track-api-calls-node-js-piwik/
+
+var PiwikTracker = require('piwik-tracker');
+
+function getRemoteAddr(req) {
+    if (req.ip) return req.ip;
+    if (req._remoteAddress) return req._remoteAddress;
+    var sock = req.socket;
+    if (sock.socket) return sock.socket.remoteAddress;
+    return sock.remoteAddress;
+}
+
+exports = module.exports = function analytics(options) {
+    var piwik = new PiwikTracker(options.siteId, options.piwikUrl);
+
+    return function track(req, res, next) {
+        piwik.track({
+            url: options.baseUrl + req.url,
+            action_name: 'API call',
+            ua: req.header('User-Agent'),
+            lang: req.header('Accept-Language'),
+            cvar: JSON.stringify({
+              '1': ['API version', 'v1'],
+              '2': ['HTTP method', req.method]
+            }),
+            token_auth: options.piwikToken,
+            cip: getRemoteAddr(req)
+
+        });
+        next();
+    }
+}

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -1,7 +1,8 @@
 // Piwik tracking middleware, from https://piwik.org/blog/2014/06/track-api-calls-node-js-piwik/
 
-var PiwikTracker = require('piwik-tracker');
+const PiwikTracker = require('piwik-tracker');
 const config = require('../config/config');
+const url = require('url');
 
 function getRemoteAddr(req) {
     if (req.ip) return req.ip;
@@ -15,14 +16,18 @@ exports = module.exports = function analytics(options) {
     var piwik = new PiwikTracker(options.siteId, options.piwikUrl);
 
     return function track(req, res, next) {
+        let parsedURL = url.parse(config.tracking.piwikBaseURL + req.url);
         let extended = false;
-        let splitURL = req.url.split('/');
+        let splitURL = parsedURL.pathname.split('/');
         let action = splitURL[4];
+        let doi;
         if (splitURL[splitURL.length - 1] === 'extended') {
-            action = 'smallBadge / ' + action;
+            action = 'bigBadge / ' + action;
+            doi = splitURL[splitURL.length - 2];
             extended = true;
         } else {
-            action = 'bigBadge / ' + action;
+            action = 'smallBadge / ' + action;
+            doi = splitURL[splitURL.length - 1];
         }
         piwik.track({
             url: options.baseUrl + req.url,
@@ -32,7 +37,8 @@ exports = module.exports = function analytics(options) {
             cvar: JSON.stringify({
                 '1': ['API version', config.api_version],
                 '2': ['HTTP method', req.method],
-                '3': ['extended', extended]
+                '3': ['extended', extended],
+                '4': ['doi', doi]
             }),
             token_auth: options.piwikToken,
             cip: getRemoteAddr(req),

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -36,7 +36,7 @@ exports = module.exports = function analytics(options) {
                     service,
                     size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
                     format = (parsedURL.query === undefined) ? null : parsedURL.query.format,
-                    referrer = req.header('referer');
+                    referrer = (req.header('referer') === undefined) ? req.header('x-research-website') : req.header('referer');
 
                 if (req.res._headers['x-badger-service'] !== undefined) {
                     service = req.res._headers['x-badger-service'];

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -1,6 +1,7 @@
-// piwik tracking middleware, from https://piwik.org/blog/2014/06/track-api-calls-node-js-piwik/
+// Piwik tracking middleware, from https://piwik.org/blog/2014/06/track-api-calls-node-js-piwik/
 
 var PiwikTracker = require('piwik-tracker');
+const config = require('../config/config');
 
 function getRemoteAddr(req) {
     if (req.ip) return req.ip;
@@ -14,19 +15,29 @@ exports = module.exports = function analytics(options) {
     var piwik = new PiwikTracker(options.siteId, options.piwikUrl);
 
     return function track(req, res, next) {
+        let extended = false;
+        let splitURL = req.url.split('/');
+        let action = splitURL[4];
+        if (splitURL[splitURL.length - 1] === 'extended') {
+            action = 'smallBadge / ' + action;
+            extended = true;
+        } else {
+            action = 'bigBadge / ' + action;
+        }
         piwik.track({
             url: options.baseUrl + req.url,
-            action_name: 'API call',
+            action_name: action,
             ua: req.header('User-Agent'),
             lang: req.header('Accept-Language'),
             cvar: JSON.stringify({
-              '1': ['API version', 'v1'],
-              '2': ['HTTP method', req.method]
+                '1': ['API version', config.api_version],
+                '2': ['HTTP method', req.method],
+                '3': ['extended', extended]
             }),
             token_auth: options.piwikToken,
-            cip: getRemoteAddr(req)
-
+            cip: getRemoteAddr(req),
+            urlref: req.header('referer')
         });
-        next();
+        next(); 
     }
 }

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -28,31 +28,19 @@ exports = module.exports = function analytics(options) {
             // get parameters from URL
             try {
                 let action,
-                    doi,
-                    extended = false,
-                    parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
-                    splitURL = parsedURL.pathname.split('/'),
-                    type = splitURL[4],
-                    service,
-                    size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
-                    format = (parsedURL.query === undefined) ? null : parsedURL.query.format,
-                    referrer = (req.header('referer') === undefined) ? req.header('x-research-website') : req.header('referer');
-
-                if (req.res._headers['x-badger-service'] !== undefined) {
-                    service = req.res._headers['x-badger-service'];
-                } else if (this._headers.location !== undefined) {
-                    let locationArray = this._headers.location.split('service=');
-                    service = locationArray[locationArray.length - 1];
-                }             
-
-                if (splitURL[splitURL.length - 1] === 'extended') {
+                    doi = res.tracking.doi,
+                    extended = res.tracking.extended,
+                    type = res.tracking.type,
+                    service = res.tracking.service,
+                    size = res.tracking.size,
+                    format = res.tracking.format,
+                    researchWebsite = req.header('x-research-website'),
+                    na = res.na;
+  
+                if (extended) {
                     action = 'bigBadge / ' + type;
-                    doi = decodeURIComponent(splitURL[splitURL.length - 2]);
-                    extended = true;
                 } else {
                     action = 'smallBadge / ' + type;
-                    doi = splitURL[splitURL.length - 1];
-                    extended = false;
                 }
 
                 // send information to piwik server
@@ -62,10 +50,10 @@ exports = module.exports = function analytics(options) {
                     ua: req.header('User-Agent'),
                     lang: req.header('Accept-Language'),
                     cvar: JSON.stringify({
-                        '1': ['API version', config.api_version],
+                        '1': ['NA Badge', na],
                         '2': ['Badger version', config.version],
                         '3': ['Extender version', req.header('x-extender-version')],
-                        '4': ['Research website', referrer],
+                        '4': ['Research website', researchWebsite],
                         '5': ['type', type],
                         '6': ['service', service],
                         '7': ['format', format],
@@ -75,7 +63,7 @@ exports = module.exports = function analytics(options) {
                     }),
                     token_auth: options.piwikToken,
                     cip: getRemoteAddr(req),
-                    urlref: referrer
+                    urlref: req.header('referer')
                 });  
             } catch (err) {
                 debug('Error parsing tracking data:');

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -3,6 +3,7 @@
 const PiwikTracker = require('piwik-tracker');
 const config = require('../config/config');
 const url = require('url');
+const debug = require('debug')('badger');
 
 function getRemoteAddr(req) {
     if (req.ip) return req.ip;
@@ -16,45 +17,59 @@ exports = module.exports = function analytics(options) {
     var piwik = new PiwikTracker(options.siteId, options.piwikUrl);
 
     return function track(req, res, next) {
-        // get parameters from URL
-        let doi,
-            extended = false,
-            parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
-            splitURL = parsedURL.pathname.split('/'),
-            type = splitURL[4],
-            size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
-            format = (parsedURL.query === undefined) ? null : parsedURL.query.format;
+        // handle requests after they have finished
+        res.on('finish', function(){
+            debug('piwik tracking info for request %s', req.url);
+            // get parameters from URL
+                let action,
+                doi,
+                extended = false,
+                parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
+                splitURL = parsedURL.pathname.split('/'),
+                type = splitURL[4],
+                service = null,
+                size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
+                format = (parsedURL.query === undefined) ? null : parsedURL.query.format;
 
-        if (splitURL[splitURL.length - 1] === 'extended') {
-            type = 'bigBadge / ' + type;
-            doi = splitURL[splitURL.length - 2];
-            extended = true;
-        } else {
-            type = 'smallBadge / ' + type;
-            doi = splitURL[splitURL.length - 1];
-        }
+                if (req.res._headers['x-badger-service'] !== undefined) {
+                    service = req.res._headers['x-badger-service'];
+                } else if (this._headers.location !== undefined) {
+                    let locationArray = this._headers.location.split('service=');
+                    service = locationArray[locationArray.length - 1];
+                }                
 
-        // send information to piwik server
-        piwik.track({
-            url: options.baseUrl + req.url,
-            action_name: type,
-            ua: req.header('User-Agent'),
-            lang: req.header('Accept-Language'),
-            cvar: JSON.stringify({
-                '1': ['API version', config.api_version],
-                '2': ['Badger version', config.version],
-                '3': ['Extender version', req.header('x-extender-version')],
-                '4': ['HTTP method', req.method],
-                '5': ['type', type],
-                '6': ['format', format],
-                '7': ['extended', extended],
-                '8': ['doi', doi],
-                '9': ['size', size]
-            }),
-            token_auth: options.piwikToken,
-            cip: getRemoteAddr(req),
-            urlref: req.header('referer')
+            if (splitURL[splitURL.length - 1] === 'extended') {
+                action = 'bigBadge / ' + type;
+                doi = decodeURIComponent(splitURL[splitURL.length - 2]);
+                extended = true;
+            } else {
+                type = 'smallBadge / ' + type;
+                doi = splitURL[splitURL.length - 1];
+            }
+
+            // send information to piwik server
+            piwik.track({
+                url: options.baseUrl + req.url,
+                action_name: action,
+                ua: req.header('User-Agent'),
+                lang: req.header('Accept-Language'),
+                cvar: JSON.stringify({
+                    '1': ['API version', config.api_version],
+                    '2': ['Badger version', config.version],
+                    '3': ['Extender version', req.header('x-extender-version')],
+                    '4': ['HTTP method', req.method],
+                    '5': ['type', type],
+                    '6': ['service', service],
+                    '7': ['format', format],
+                    '8': ['extended', extended],
+                    '9': ['doi', doi],
+                    '10': ['size', size]
+                }),
+                token_auth: options.piwikToken,
+                cip: getRemoteAddr(req),
+                urlref: req.header('referer')
+            });  
         });
-        next(); 
+        next();
     }
 }

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -33,7 +33,7 @@ exports = module.exports = function analytics(options) {
                     parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
                     splitURL = parsedURL.pathname.split('/'),
                     type = splitURL[4],
-                    service = null,
+                    service,
                     size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
                     format = (parsedURL.query === undefined) ? null : parsedURL.query.format,
                     referrer = req.header('referer');
@@ -50,8 +50,9 @@ exports = module.exports = function analytics(options) {
                     doi = decodeURIComponent(splitURL[splitURL.length - 2]);
                     extended = true;
                 } else {
-                    type = 'smallBadge / ' + type;
+                    action = 'smallBadge / ' + type;
                     doi = splitURL[splitURL.length - 1];
+                    extended = false;
                 }
 
                 // send information to piwik server
@@ -64,7 +65,7 @@ exports = module.exports = function analytics(options) {
                         '1': ['API version', config.api_version],
                         '2': ['Badger version', config.version],
                         '3': ['Extender version', req.header('x-extender-version')],
-                        '4': ['HTTP method', req.method],
+                        '4': ['Research website', referrer],
                         '5': ['type', type],
                         '6': ['service', service],
                         '7': ['format', format],

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -53,34 +53,34 @@ exports = module.exports = function analytics(options) {
                     type = 'smallBadge / ' + type;
                     doi = splitURL[splitURL.length - 1];
                 }
+
+                // send information to piwik server
+                piwik.track({
+                    url: options.baseUrl + req.url,
+                    action_name: action,
+                    ua: req.header('User-Agent'),
+                    lang: req.header('Accept-Language'),
+                    cvar: JSON.stringify({
+                        '1': ['API version', config.api_version],
+                        '2': ['Badger version', config.version],
+                        '3': ['Extender version', req.header('x-extender-version')],
+                        '4': ['HTTP method', req.method],
+                        '5': ['type', type],
+                        '6': ['service', service],
+                        '7': ['format', format],
+                        '8': ['extended', extended],
+                        '9': ['doi', doi],
+                        '10': ['size', size]
+                    }),
+                    token_auth: options.piwikToken,
+                    cip: getRemoteAddr(req),
+                    urlref: referrer
+                });  
             } catch (err) {
                 debug('Error parsing tracking data:');
                 debug(err);
                 return;
             }
-
-            // send information to piwik server
-            piwik.track({
-                url: options.baseUrl + req.url,
-                action_name: action,
-                ua: req.header('User-Agent'),
-                lang: req.header('Accept-Language'),
-                cvar: JSON.stringify({
-                    '1': ['API version', config.api_version],
-                    '2': ['Badger version', config.version],
-                    '3': ['Extender version', req.header('x-extender-version')],
-                    '4': ['HTTP method', req.method],
-                    '5': ['type', type],
-                    '6': ['service', service],
-                    '7': ['format', format],
-                    '8': ['extended', extended],
-                    '9': ['doi', doi],
-                    '10': ['size', size]
-                }),
-                token_auth: options.piwikToken,
-                cip: getRemoteAddr(req),
-                urlref: referrer
-            });  
         });
         next();
     }

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -35,7 +35,7 @@ exports = module.exports = function analytics(options) {
                     size = res.tracking.size,
                     format = res.tracking.format,
                     researchWebsite = req.header('x-research-website'),
-                    na = res.na;
+                    na = (res.na === true) ? true : false;
   
                 if (extended) {
                     action = 'bigBadge / ' + type;

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -16,11 +16,13 @@ exports = module.exports = function analytics(options) {
     var piwik = new PiwikTracker(options.siteId, options.piwikUrl);
 
     return function track(req, res, next) {
-        let parsedURL = url.parse(config.tracking.piwikBaseURL + req.url);
-        let extended = false;
-        let splitURL = parsedURL.pathname.split('/');
-        let action = splitURL[4];
-        let doi;
+        // get parameters from URL
+        let doi,
+            extended = false,
+            parsedURL = url.parse(config.tracking.piwikBaseURL + req.url),
+            splitURL = parsedURL.pathname.split('/'),
+            action = splitURL[4];
+
         if (splitURL[splitURL.length - 1] === 'extended') {
             action = 'bigBadge / ' + action;
             doi = splitURL[splitURL.length - 2];
@@ -38,7 +40,8 @@ exports = module.exports = function analytics(options) {
                 '1': ['API version', config.api_version],
                 '2': ['HTTP method', req.method],
                 '3': ['extended', extended],
-                '4': ['doi', doi]
+                '4': ['doi', doi],
+                '5': ['size', parsedURL.query.width]
             }),
             token_auth: options.piwikToken,
             cip: getRemoteAddr(req),

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -18,33 +18,45 @@ exports = module.exports = function analytics(options) {
 
     return function track(req, res, next) {
         // handle requests after they have finished
-        res.on('finish', function(){
+        res.on('finish', function(){    
+            if (req.header('dnt') === '1') {
+                // do not track
+                return;
+            }
             debug('piwik tracking info for request %s', req.url);
+
             // get parameters from URL
+            try {
                 let action,
-                doi,
-                extended = false,
-                parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
-                splitURL = parsedURL.pathname.split('/'),
-                type = splitURL[4],
-                service = null,
-                size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
-                format = (parsedURL.query === undefined) ? null : parsedURL.query.format;
+                    doi,
+                    extended = false,
+                    parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
+                    splitURL = parsedURL.pathname.split('/'),
+                    type = splitURL[4],
+                    service = null,
+                    size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
+                    format = (parsedURL.query === undefined) ? null : parsedURL.query.format,
+                    referrer = req.header('referer');
 
                 if (req.res._headers['x-badger-service'] !== undefined) {
                     service = req.res._headers['x-badger-service'];
                 } else if (this._headers.location !== undefined) {
                     let locationArray = this._headers.location.split('service=');
                     service = locationArray[locationArray.length - 1];
-                }                
+                }             
 
-            if (splitURL[splitURL.length - 1] === 'extended') {
-                action = 'bigBadge / ' + type;
-                doi = decodeURIComponent(splitURL[splitURL.length - 2]);
-                extended = true;
-            } else {
-                type = 'smallBadge / ' + type;
-                doi = splitURL[splitURL.length - 1];
+                if (splitURL[splitURL.length - 1] === 'extended') {
+                    action = 'bigBadge / ' + type;
+                    doi = decodeURIComponent(splitURL[splitURL.length - 2]);
+                    extended = true;
+                } else {
+                    type = 'smallBadge / ' + type;
+                    doi = splitURL[splitURL.length - 1];
+                }
+            } catch (err) {
+                debug('Error parsing tracking data:');
+                debug(err);
+                return;
             }
 
             // send information to piwik server
@@ -67,7 +79,7 @@ exports = module.exports = function analytics(options) {
                 }),
                 token_auth: options.piwikToken,
                 cip: getRemoteAddr(req),
-                urlref: req.header('referer')
+                urlref: referrer
             });  
         });
         next();

--- a/lib/express-piwik-tracker.js
+++ b/lib/express-piwik-tracker.js
@@ -19,29 +19,37 @@ exports = module.exports = function analytics(options) {
         // get parameters from URL
         let doi,
             extended = false,
-            parsedURL = url.parse(config.tracking.piwikBaseURL + req.url),
+            parsedURL = url.parse(config.tracking.piwikBaseURL + req.url, true),
             splitURL = parsedURL.pathname.split('/'),
-            action = splitURL[4];
+            type = splitURL[4],
+            size = (parsedURL.query === undefined) ? null : parsedURL.query.width,
+            format = (parsedURL.query === undefined) ? null : parsedURL.query.format;
 
         if (splitURL[splitURL.length - 1] === 'extended') {
-            action = 'bigBadge / ' + action;
+            type = 'bigBadge / ' + type;
             doi = splitURL[splitURL.length - 2];
             extended = true;
         } else {
-            action = 'smallBadge / ' + action;
+            type = 'smallBadge / ' + type;
             doi = splitURL[splitURL.length - 1];
         }
+
+        // send information to piwik server
         piwik.track({
             url: options.baseUrl + req.url,
-            action_name: action,
+            action_name: type,
             ua: req.header('User-Agent'),
             lang: req.header('Accept-Language'),
             cvar: JSON.stringify({
                 '1': ['API version', config.api_version],
-                '2': ['HTTP method', req.method],
-                '3': ['extended', extended],
-                '4': ['doi', doi],
-                '5': ['size', parsedURL.query.width]
+                '2': ['Badger version', config.version],
+                '3': ['Extender version', req.header('x-extender-version')],
+                '4': ['HTTP method', req.method],
+                '5': ['type', type],
+                '6': ['format', format],
+                '7': ['extended', extended],
+                '8': ['doi', doi],
+                '9': ['size', size]
             }),
             token_auth: options.piwikToken,
             cip: getRemoteAddr(req),

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   "author": "o2r-project (http://o2r.info)",
   "license": "Apache-2.0",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/o2r-project/o2r-badger.git"
+    "type": "git",
+    "url": "https://github.com/o2r-project/o2r-badger.git"
   },
   "dependencies": {
     "body-parser": "latest",
     "debug": "^2.6.4",
     "express": "^4.14.0",
+    "piwik-tracker": "^1.1.2",
     "request": "^2.79.0",
     "svg2png": "^4.1.0",
     "xmldom": "^0.1.27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o2r-badger",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Generate scalable badges for research",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "piwik-tracker": "^1.1.2",
     "request": "^2.79.0",
     "svg2png": "^4.1.0",
-    "xmldom": "^0.1.27"
+    "xmldom": "^0.1.27",
+    "yn": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
- adds tracking for all API requests
- include additional info via custom variables
- no tracking when `dnt` header is sent
- update readme with required configuration and environment variables

closes #11 